### PR TITLE
Allow organisations in Iglu schema URIs to contain hyphens

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/json/JsonShredder.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/json/JsonShredder.scala
@@ -39,7 +39,7 @@ import scala.annotation.tailrec
  */
 object JsonShredder {
 
-  private val schemaPattern = """.+:([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_]+)/[^/]+/(.*)""".r
+  private val schemaPattern = """.+:([a-zA-Z0-9_\.\-]+)/([a-zA-Z0-9_]+)/[^/]+/(.*)""".r
 
   /**
    * Create an Elasticsearch field name from a schema
@@ -57,7 +57,7 @@ object JsonShredder {
       case schemaPattern(organization, name, schemaVer) => {
 
         // Split the vendor's reversed domain name using underscores rather than dots
-        val snakeCaseOrganization = organization.replaceAll("""\.""", "_").toLowerCase
+        val snakeCaseOrganization = organization.replaceAll("""[\.\-]""", "_").toLowerCase
 
         // Change the name from PascalCase to snake_case if necessary
         val snakeCaseName = name.replaceAll("([^A-Z_])([A-Z])", "$1_$2").toLowerCase

--- a/src/test/scala/com.snowplowanalytics.snowplow.analytics.scalasdk.json/JsonShredderSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.analytics.scalasdk.json/JsonShredderSpec.scala
@@ -136,7 +136,7 @@ class JsonShredderSpec extends Specification with ValidationMatchers {
       val expected = NonEmptyList(
         "Could not extract inner data field from custom context",
         "Context JSON did not contain a stringly typed schema field",
-        """Schema failing does not conform to regular expression .+:([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_]+)/[^/]+/(.*)""")
+        """Schema failing does not conform to regular expression .+:([a-zA-Z0-9_\.\-]+)/([a-zA-Z0-9_]+)/[^/]+/(.*)""")
 
       actual must be failing(expected)
     }


### PR DESCRIPTION
Allows shredding of com.google.analytics.enhanced-ecommerce events.

I'm using the Scala SDK to transform enriched events (held in s3) via AWS Lambda but hit an issue where transforming GA enhanced ecommerce events fails the regex.

Can I get some feedback so I know I'm on the right track? Thanks.